### PR TITLE
Pass command object instead of string to hdrs.changeSetting()

### DIFF
--- a/node-tcc-honeywell.js
+++ b/node-tcc-honeywell.js
@@ -58,11 +58,15 @@ module.exports = function(RED) {
 				node.send(msg);
 			};
             var process = function() {
-                if (typeof msg.payload !== 'string') msg.payload = JSON.stringify(msg.payload);
-                if (msg.payload.charAt(0) === '{') {										// it is a command
-                    tccRequest(node, hdrs.changeSetting(node, msg.payload), 'TCC Command ' + msg.payload + ': ', ConnectSuccess, sendMsg);
-                } else {																	// it is a status request
-                    tccRequest(node, hdrs.getStatus(node), 'TCC Status GET', ConnectSuccess, sendMsg);
+                if (typeof msg.payload !== 'string') {		// it is a command
+                    tccRequest(node, 
+															 hdrs.changeSetting(node, msg.payload), 
+															 'TCC Command ' + 
+																	JSON.stringify(msg.payload) + ': ', 
+															 ConnectSuccess, sendMsg);
+                } else {									// it is a status request
+                    tccRequest(node, hdrs.getStatus(node), 
+															 'TCC Status GET', ConnectSuccess, sendMsg);
                 }
             };
             if (node.connected) process(); else tccLogin(node, function(node) {setTimeout(process, 1000)});	// added a delay to see if needed (?)


### PR DESCRIPTION
Code wasn't changing thermostat settings because msg.payload was being converted to a JSON string prior to being passed to hdrs.changeSettings(). In changeSettings(), it was expecting an object to merge into the POST data -- the string couldn't be merged which resulted in a null (default) command submission to the Honeywell API, effectively making no changes to the settings regardless of the passed in command object in msg.payload. 
This patch now passes the object as expected and can now change settings on connected thermostats.